### PR TITLE
fix: wrong url

### DIFF
--- a/site/docs/getting_started/introduction.md
+++ b/site/docs/getting_started/introduction.md
@@ -8,7 +8,7 @@ Along with some pre-configured configs to get you started!
 
 ## Installation
 
-You can refere to [dooit's installation guide](/) which also includes `dooit-extras`
+You can refere to [dooit's installation guide](https://dooit-org.github.io/dooit/getting_started/installation.html) which also includes `dooit-extras`
 
 :::tip :grey_exclamation: NOTE
 Dooit extras uses [`Nerd Font Icons`](https://www.nerdfonts.com/) for everything, so make sure you're using that \

--- a/site/docs/getting_started/introduction.md
+++ b/site/docs/getting_started/introduction.md
@@ -8,7 +8,7 @@ Along with some pre-configured configs to get you started!
 
 ## Installation
 
-You can refere to [dooit's installation guide](https://dooit-org.github.io/dooit/getting_started/installation.html) which also includes `dooit-extras`
+You can refer to [dooit's installation guide](https://dooit-org.github.io/dooit/getting_started/installation.html) which also includes `dooit-extras`
 
 :::tip :grey_exclamation: NOTE
 Dooit extras uses [`Nerd Font Icons`](https://www.nerdfonts.com/) for everything, so make sure you're using that \


### PR DESCRIPTION
The "dooit's installation guide" link should point to [installation page of dooit](https://dooit-org.github.io/dooit/getting_started/installation.html) instead of the root url which is <https://dooit-org.github.io/dooit-extras/>.